### PR TITLE
Support for hiking workout type

### DIFF
--- a/GpxExport/WorkoutDataStore.swift
+++ b/GpxExport/WorkoutDataStore.swift
@@ -105,6 +105,7 @@ class WorkoutDataStore {
             HKQuery.predicateForWorkouts(with: .running),
             HKQuery.predicateForWorkouts(with: .cycling),
             HKQuery.predicateForWorkouts(with: .swimming),
+            HKQuery.predicateForWorkouts(with: .hiking)
             ])
         
         let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)


### PR DESCRIPTION
In a recent version of watchOS/iOS, there was a hiking workout type added that logs route data. I have added this to the predicate for fetching workouts from the HealthKit data store so that hiking workouts show up in the app and can be exported. I think this was the only new workout type with route logging added, or at least the only one available in the default Watch Workout app. 

I have tested this change on the latest iOS 12.3 developer beta with a hiking workout and it works.